### PR TITLE
Add `express` benchmark.

### DIFF
--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -1,0 +1,12 @@
+all:
+	@./run 1 middleware
+	@./run 5 middleware
+	@./run 10 middleware
+	@./run 15 middleware
+	@./run 20 middleware
+	@./run 30 middleware
+	@./run 50 middleware
+	@./run 100 middleware
+	@echo
+
+.PHONY: all

--- a/benchmark/middleware.js
+++ b/benchmark/middleware.js
@@ -1,0 +1,23 @@
+var compose = require('lodash/flowRight');
+var http = require('http');
+var send = require('../middleware/send').default;
+var connect = require('../adapter/http').default;
+
+var app = send('Hello World');
+var noop = function(app) {
+  return {
+    request(req, res) {
+      app.request(req, res);
+    },
+  };
+};
+
+// number of middleware
+var n = parseInt(process.env.MW || '1', 10);
+console.log('  %s middleware', n);
+
+while (n--) {
+  app = compose(noop, app);
+}
+
+connect(app(), http.createServer()).listen(3333);

--- a/benchmark/run
+++ b/benchmark/run
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo
+MW=$1 node $2 &
+pid=$!
+
+sleep 2
+
+wrk 'http://localhost:3333/?foo[bar]=baz' \
+  -d 3 \
+  -c 50 \
+  -t 8 \
+  | grep 'Requests/sec' \
+  | awk '{ print "  " $2 }'
+
+kill $pid


### PR DESCRIPTION
Don't really know if this is useful, but it's the analog to the same `express` benchmark found in their repository: https://github.com/strongloop/express/tree/master/benchmarks. Tested results are, however, very promising:

`express`:

```
100 middleware
4012.69 req/s
```

`http-middleware`:

```
100 middleware
10723.72 req/s
```

**NOTE**: Have to disable lint yet.

/cc @nealgranger 
