### PR TITLE
Add header and status presets.

### DIFF
--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -61,7 +61,7 @@ const header = (header, getValue) => (app) => {
         .then(finalGetValue)
         .then((value) => {
           value && res.setHeader(header, value);
-          app.request(req, res);
+          return app.request(req, res);
         })
         .catch((err) => app.error(err, req, res));
     },

--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -1,6 +1,58 @@
 import isFunction from 'lodash/isFunction';
 
-export default (header, getValue) => (app) => {
+export const headerPresets = {
+  acceptPatch: 'Accept-Patch',
+  acceptRanges: 'Accept-Ranges',
+  accessControlAllowOrigin: 'Access-Control-Allow-Origin',
+  age: 'Age',
+  allow: 'Allow',
+  cacheControl: 'Cache-Control',
+  connection: 'Connection',
+  contentDisposition: 'Content-Disposition',
+  contentEncoding: 'Content-Encoding',
+  contentLanguage: 'Content-Language',
+  contentLength: 'Content-Length',
+  contentLocation: 'Content-Location',
+  contentMd5: 'Content-MD5',
+  contentRange: 'Content-Range',
+  contentSecurityPolicy: 'Content-Security-Policy',
+  contentType: 'Content-Type',
+  date: 'Date',
+  etag: 'ETag',
+  expires: 'Expires',
+  lastModified: 'Last-Modified',
+  link: 'Link',
+  location: 'Location',
+  p3p: 'P3P',
+  pragma: 'Pragma',
+  proxyAuthenticate: 'Proxy-Authenticate',
+  publicKeyPins: 'Public-Key-Pins',
+  refresh: 'Refresh',
+  retryAfter: 'Retry-After',
+  server: 'Server',
+  setCookie: 'Set-Cookie',
+  status: 'Status',
+  strictTransportSecurity: 'Strict-Transport-Security',
+  trailer: 'Trailer',
+  transferEncoding: 'Transfer-Encoding',
+  tsv: 'TSV',
+  upgrade: 'Upgrade',
+  vary: 'Vary',
+  via: 'Via',
+  warning: 'Warning',
+  wwwAuthenticate: 'WWW-Authenticate',
+  xContentDuration: 'X-Content-Duration',
+  xContentSecurityPolicy: 'X-Content-Security-Policy',
+  xContentTypeOptions: 'X-Content-Type-Options',
+  xDownloadOptions: 'X-Download-Options',
+  xFrameOptions: 'X-Frame-Options',
+  xPoweredBy: 'X-Powered-By',
+  xUaCompatible: 'X-UA-Compatible',
+  xWebkitCsp: 'X-Webkit-CSP',
+  xXssProtection: 'X-XSS-Protection',
+};
+
+const header = (header, getValue) => (app) => {
   const finalGetValue = isFunction(getValue) ? getValue : () => getValue;
   return {
     ...app,
@@ -16,3 +68,8 @@ export default (header, getValue) => (app) => {
   };
 };
 
+Object.keys(headerPresets).forEach((key) => {
+  header[key] = header.bind(null, headerPresets[key]);
+});
+
+export default header;

--- a/src/middleware/secure.js
+++ b/src/middleware/secure.js
@@ -1,28 +1,26 @@
+import identity from 'lodash/identity';
+import compose from 'lodash/flowRight';
+
+import header from './header';
 /**
  * [function description]
  * @param {Boolean} secure True to enable security features.
  * @returns {Function} Middleware function.
  */
-export default function({
+export default ({
   secure = process.env.NODE_ENV === 'production',
-} = { }) {
-  return function(app) {
-    if (!secure) {
-      return app;
-    }
-    const { request } = app;
-    return {
-      ...app,
-      request(req, res) {
-        // https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-        res.setHeader('Strict-Transport-Security', 'max-age=16070400');
-        res.setHeader('X-Frame-Options', 'deny');
-        res.setHeader('X-XSS-Protection', '1; mode=block');
-        res.setHeader('X-Download-Options', 'noopen');
-        res.setHeader('X-Content-Type-Options', 'nosniff');
-        // res.setHeader('Public-Key-Pins', '...');
-        request(req, res);
-      },
-    };
-  };
-}
+} = {}) => {
+  if (!secure) {
+    return identity;
+  }
+
+  return compose(
+    // https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+    header.strictTransportSecurity('max-age=16070400'),
+    header.xFrameOptions('deny'),
+    header.xXssProtection('1; mode=block'),
+    header.xDownloadOptions('noopen'),
+    header.xContentTypeOptions('nosniff'),
+    // header.publicKeyPins('...');
+  );
+};

--- a/src/middleware/status.js
+++ b/src/middleware/status.js
@@ -1,6 +1,51 @@
 import isFunction from 'lodash/isFunction';
 
-export default (getStatus) => (app) => {
+const statusPresets = {
+  continue: 100,
+  switchingProtocols: 101,
+  ok: 200,
+  created: 201,
+  accepted: 202,
+  nonAuthoritativeInformation: 203,
+  noContent: 204,
+  resetContent: 205,
+  partialContent: 206,
+  multipleChoices: 300,
+  movedPermanently: 301,
+  found: 302,
+  seeOther: 303,
+  notModified: 304,
+  useProxy: 305,
+  temporaryRedirect: 307,
+  badRequest: 400,
+  unauthorized: 401,
+  paymentRequired: 402,
+  forbidden: 403,
+  notFound: 404,
+  methodNotAllowed: 405,
+  notAcceptable: 406,
+  proxyAuthenticationRequired: 407,
+  requestTimeout: 408,
+  conflict: 409,
+  gone: 410,
+  lengthRequired: 411,
+  preconditionFailed: 412,
+  requestEntityTooLarge: 413,
+  requestUriTooLong: 414,
+  unsupportedMediaType: 415,
+  requestedRangeNotSatisfiable: 416,
+  expectationFailed: 417,
+  unprocessableEntity: 422,
+  tooManyRequests: 429,
+  internalServerError: 500,
+  notImplemented: 501,
+  badGateway: 502,
+  serviceUnavailable: 503,
+  gatewayTimeout: 504,
+  httpVersionNotSupported: 505,
+};
+
+const status = (getStatus) => (app) => {
   const finalGetStatus = isFunction(getStatus) ? getStatus : () => getStatus;
   return {
     ...app,
@@ -15,3 +60,9 @@ export default (getStatus) => (app) => {
     },
   };
 };
+
+Object.keys(statusPresets).forEach((key) => {
+  status[key] = status.bind(null, statusPresets[key]);
+});
+
+export default status;

--- a/test/spec/middleware/header.spec.js
+++ b/test/spec/middleware/header.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import header from '../../../src/middleware/header';
+import header, {headerPresets} from '../../../src/middleware/header';
 
 describe('header', () => {
   let res;
@@ -63,6 +63,27 @@ describe('header', () => {
       expect(next.error).to.be.calledWith(err, req, res);
       expect(res.setHeader).to.not.have.been.called;
       done();
+    });
+  });
+
+  describe('header presets', () => {
+    it('should have correct key-value mappings', () => {
+      const kebab = (value) => {
+        return value.replace(/([A-Z])/g, '-$1').toLowerCase();
+      };
+
+      Object.keys(headerPresets).forEach((key) => {
+        expect(kebab(key)).to.equal(headerPresets[key].toLowerCase());
+      });
+    });
+
+    it('should be available on the header middleware', (done) => {
+      const app = header.contentType('bar')(next);
+
+      app.request(req, res).then(() => {
+        expect(res.setHeader).to.be.calledWith('Content-Type', 'bar');
+        done();
+      });
     });
   });
 });

--- a/test/spec/middleware/secure.spec.js
+++ b/test/spec/middleware/secure.spec.js
@@ -3,9 +3,17 @@ import sinon from 'sinon';
 
 import secure from '../../../src/middleware/secure';
 
-it('should enable strict transport security', () => {
+it('should enable security headers', (done) => {
   const spy = sinon.spy();
-  const app = secure({ secure: true })({ request: spy });
-  app.request({}, { setHeader: spy });
-  expect(spy).to.be.calledWith('Strict-Transport-Security');
+  const res = { setHeader: spy };
+  const app = secure({ secure: true })({ request: () => {} });
+  app.request({}, res)
+    .then(() => {
+      expect(res.setHeader).to.be.calledWith('Strict-Transport-Security');
+      expect(res.setHeader).to.be.calledWith('X-Frame-Options');
+      expect(res.setHeader).to.be.calledWith('X-XSS-Protection');
+      expect(res.setHeader).to.be.calledWith('X-Download-Options');
+      expect(res.setHeader).to.be.calledWith('X-Content-Type-Options');
+      done();
+    });
 });

--- a/test/spec/middleware/status.spec.js
+++ b/test/spec/middleware/status.spec.js
@@ -63,4 +63,15 @@ describe('status', () => {
       done();
     });
   });
+
+  describe('status presets', () => {
+    it('should be available on the status middleware', (done) => {
+      const app = status.notFound()(next);
+
+      app.request(req, res).then(() => {
+        expect(res.statusCode).to.be.equal(404);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
- Add presets for standard response headers.
- Fix bug in header middleware preventing promise chain from resolving.
- Implement `secure` middleware by composing header presets.
- Add presets for standard status codes.

Preset usage is very simple:

``` diff
compose(
-  header('Content-Type', 'application/json'),
-  status(200),
+  header.contentType('application/json'),
+  status.ok(),
);
```

cc @izaakschroeder 
