### PR TITLE
Pass `req` and `res` to `serve` error handler.

### DIFF
--- a/src/serve.js
+++ b/src/serve.js
@@ -18,7 +18,7 @@ export default (options) => {
         const stream = send(req, path, options);
 
         stream
-          .on('error', error)
+          .on('error', (err) => error(err, req, res))
           // .on('directory', redirect)
           // .on('headers', headers)
           .pipe(res);


### PR DESCRIPTION
This is useful for the error handler to actually do something with the response.

/cc @nealgranger 