### PR TITLE
Allow resuming request pipeline when file not found in `serve`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "midori",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-flow": "^6.23.0",
-    "bl": "^1.0.1",
+    "bl": "^1.2.1",
     "chai": "^3.4.1",
     "chai-http": "^1.0.0",
     "eslint": "^4.5.0",

--- a/src/serve.js
+++ b/src/serve.js
@@ -3,9 +3,29 @@ import send from 'send';
 import parse from 'parseurl';
 import request from './request';
 import pure from './pure';
+import next from './next';
+import compose from './compose';
+import status from './status';
+import write from './send';
 
 import type {AppCreator} from './types';
 import type {IncomingMessage} from 'http';
+type Options = {
+  final: boolean,
+  onDirectory: (directory: string) => AppCreator,
+  acceptRanges: ?boolean,
+  cacheControl: ?boolean,
+  dotfiles: ?('allow' | 'deny' | 'ignore'),
+  end: ?number,
+  etag: ?boolean,
+  extensions: ?Array<string>,
+  immutable: ?boolean,
+  index: ?boolean,
+  lastModified: ?boolean,
+  maxAge: ?(number | string),
+  root: string,
+  start: ?number,
+};
 
 const getBase = (req: IncomingMessage): string => {
   const url: URL = parse(req);
@@ -17,16 +37,38 @@ const getBase = (req: IncomingMessage): string => {
 
 /**
  * Server static files with `send`.
- * @param {Object} options Options to pass through to `send`.
+ * @param {Object} options Options to pass through to `send`. You can see then
+ * list of parameters here: https://www.npmjs.com/package/send
+ * @param {Boolean} options.final True to terminate request handling here. You
+ * can set this to `false` if you want to keep processing the app chain if a
+ * file is not found.
+ * @param {Function} options.onDirectory Invoked with a directory path when a
+ * directory is encountered. You can use this to do things like provide a
+ * directory listing or return some other status. Defaults to returning 204.
  * @returns {Function} App creator.
  */
-export default (options: Object): AppCreator => request((req, res) => {
+export default ({
+  final = true,
+  onDirectory = () => compose(status(204), write('')),
+  ...options
+}: Options): AppCreator => request((req, res) => {
   const path = getBase(req);
-  const stream = send(req, path, options);
-  stream
-    // .on('error', (err) => app.error(err, req, res))
-    // .on('directory', redirect)
-    // .on('headers', headers)
-    .pipe(res);
-  return pure(null);
+  return new Promise((resolve, reject) => {
+    const stream = send(req, path, options);
+    stream
+      .on('error', (err) => {
+        if (err && err.code === 'ENOENT' && !final) {
+          resolve(next);
+        } else {
+          reject(err);
+        }
+      })
+      .on('directory', (res, path) => {
+        resolve(onDirectory(path));
+      })
+      .pipe(res)
+      .on('finish', () => {
+        resolve(pure(null));
+      });
+  });
 });

--- a/test/spec/logging.spec.js
+++ b/test/spec/logging.spec.js
@@ -1,7 +1,6 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import bl from 'bl';
-import onFinished from 'on-finished';
 
 import compose from '../../src/compose';
 import logging, {
@@ -12,22 +11,25 @@ import logging, {
 } from '../../src/logging';
 import send from '../../src/send';
 
-describe('logging', (done) => {
-  it('should do some things', () => {
+describe('logging', () => {
+  it('should do some things', (done) => {
     const spy = sinon.spy();
     const app = compose(
       logging(dev(spy)),
       send('test')
     )();
-    const res = bl(() => {});
+    const res = bl(() => {
+      try {
+        expect(res).not.to.be.null;
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
     res.setHeader = () => {};
     res.writeHead = () => {};
+    res.finished = false;
     app.request({}, res);
-
-    onFinished(res, () => {
-      expect(res).not.to.be.null;
-      done();
-    });
   });
 
   describe('dev', () => {

--- a/test/spec/serve.spec.js
+++ b/test/spec/serve.spec.js
@@ -1,51 +1,101 @@
+import {expect} from 'chai';
 import sinon from 'sinon';
 import bl from 'bl';
-import onFinished from 'on-finished';
+import {resolve} from 'path';
 
 import serve from '../../src/serve';
+import send from '../../src/send';
 
 describe('serve', () => {
-  it('should serve some files', (done) => {
-    const spy = sinon.spy();
-    const getHeader = sinon.stub().returns('');
-    const setHeader = sinon.stub();
-    const stream = bl(() => {});
-    const app = serve({root: __dirname})({
-      request: spy,
-      error: done,
+  let getHeader;
+  let setHeader;
+  let stream;
+  let result;
+  let nextApp;
+
+  beforeEach(() => {
+    getHeader = sinon.stub().returns('');
+    setHeader = sinon.stub();
+    result = new Promise((resolve, reject) => {
+      nextApp = {
+        request: () => resolve(null),
+        error: reject,
+      };
+      stream = bl((err, result) => {
+        err ? reject(err) : resolve(result);
+      });
     });
+    stream.finished = false;
     stream.getHeader = getHeader;
     stream.setHeader = setHeader;
-    onFinished(stream, (err) => {
-      // FIXME: This appears to be called out of order...
-      // expect(stream.setHeader).to.be.called;
-      done(err);
-    });
-    app.request({url: '/serve.spec.js', headers: {}, method: 'GET'}, stream);
   });
 
-  it('should work with path prefixes', (done) => {
-    const spy = sinon.spy();
-    const getHeader = sinon.stub().returns('');
-    const setHeader = sinon.stub();
-    const stream = bl(() => {});
-    const app = serve({root: __dirname})({
-      request: spy,
-      error: done,
+  it('should serve some files', () => {
+    const app = serve({root: __dirname})();
+    app.request({url: '/serve.spec.js', headers: {}, method: 'GET'}, stream);
+    return result.then((data) => {
+      expect(data.toString()).to.contain('import bl');
     });
-    stream.getHeader = getHeader;
-    stream.setHeader = setHeader;
-    // fs.createReadStream('./base.js').pipe(stream);
+  });
+
+  it('should work with path prefixes', () => {
+    const app = serve({root: __dirname})(nextApp);
     app.request({
       url: '/foo/serve.spec.js',
       path: '/foo',
       headers: {},
       method: 'GET',
     }, stream);
-    onFinished(stream, (err) => {
-      // FIXME: This appears to be called out of order...
-      // expect(stream.setHeader).to.be.called;
-      done(err);
+    return result.then((data) => {
+      expect(data.toString()).to.contain('import bl');
+    });
+  });
+
+  it('should call next handler with `final` set to `false`', () => {
+    const app = serve({root: __dirname, final: false})(nextApp);
+    app.request({url: '/404', headers: {}, method: 'GET'}, stream);
+    return result.then((data) => {
+      expect(data).to.be.null;
+    });
+  });
+
+  it('should invoke directory handler on directories', () => {
+    const spy = sinon.spy();
+    const app = serve({
+      root: __dirname,
+      index: false,
+      onDirectory: (path) => {
+        spy(resolve(path));
+        return send('');
+      },
+    })(nextApp);
+    app.request({url: '/', headers: {}, method: 'GET'}, stream);
+    return result.then((data) => {
+      expect(data.length).to.equal(0);
+      expect(spy).to.be.calledOnce;
+    });
+  });
+
+  it('should by default return `204` on directories', () => {
+    const app = serve({
+      root: __dirname,
+      index: false,
+    })(nextApp);
+    app.request({url: '/', headers: {}, method: 'GET'}, stream);
+    return result.then((data) => {
+      expect(data.length).to.equal(0);
+      expect(stream.statusCode).to.equal(204);
+    });
+  });
+
+  it('should invoke error handler on errors', () => {
+    const app = serve({root: __dirname})(nextApp);
+    app.request({url: '/404', headers: {}, method: 'GET'}, stream);
+    return result.then(() => {
+      throw new Error();
+    }, (err) => {
+      expect(err).to.have.property('statusCode', 404);
+      return Promise.resolve();
     });
   });
 });

--- a/test/spec/timing.spec.js
+++ b/test/spec/timing.spec.js
@@ -6,22 +6,26 @@ import compose from '../../src/compose';
 import timing from '../../src/timing';
 import send from '../../src/send';
 
-describe('timing', (done) => {
-  it('should do some math', () => {
+describe('timing', () => {
+  it('should do some math', (done) => {
     const app = compose(
       timing(),
       send('test')
     )();
-    const res = bl(() => {});
     const req = bl('test');
+    const res = bl(() => {});
     res.setHeader = () => {};
     res.writeHead = () => {};
+    res.finished = false;
     app.request(req, res);
-
     onFinished(res, () => {
-      expect(res).to.have.property('timing').to.have.property('end');
-      expect(req).to.have.property('timing').to.have.property('end');
-      done();
+      try {
+        expect(res).to.have.property('timing').to.have.property('end');
+        expect(req).to.have.property('timing').to.have.property('start');
+        done();
+      } catch (err) {
+        done(err);
+      }
     });
   });
 });


### PR DESCRIPTION
This allows for doing other processing instead of just sending back the 404 response. Additionally, error handling has been brought back and any errors encountered in `serve` will be propagated into the pipeline.