### PR TITLE
Prevent `upgrade` default handler with other listeners present.

### DIFF
--- a/src/internal/baseApp.js
+++ b/src/internal/baseApp.js
@@ -17,9 +17,19 @@ const baseApp = {
     }
   },
   upgrade(req, socket, _head) {
-    socket.write('HTTP/1.1 501 Not Implemented\r\n' +
-               'Connection: Close\r\n' +
-               '\r\n');
+    // There isn't really a "catch-all" like `res.finished` for the `upgrade`
+    // event. So if we're the only listener then we know we can close the
+    // connection. Otherwise we just pray whomever else has attached to the
+    // event knows what they're doing.
+    if (
+      typeof this.listenerCount !== 'function' ||
+      this.listenerCount('upgrade') === 1
+    ) {
+      socket.end('HTTP/1.1 501 Not Implemented\r\n' +
+        'Connection: Close\r\n' +
+        '\r\n'
+      );
+    }
   },
   listening() {
 

--- a/test/spec/internal/baseApp.spec.js
+++ b/test/spec/internal/baseApp.spec.js
@@ -45,8 +45,22 @@ describe('internal/baseApp', () => {
   });
 
   it('should provide a default upgrade handler', () => {
-    const socket = {write: sinon.spy()};
+    const socket = {end: sinon.spy()};
     baseApp.upgrade({}, socket);
-    expect(socket.write).to.be.called;
+    expect(socket.end).to.be.called;
+  });
+
+  it('should not call upgrade handler if one listener', () => {
+    const socket = {end: sinon.spy()};
+    baseApp.listenerCount = () => 1;
+    baseApp.upgrade({}, socket);
+    expect(socket.end).to.be.called;
+  });
+
+  it('should not call upgrade handler if other listeners', () => {
+    const socket = {end: sinon.spy()};
+    baseApp.listenerCount = () => 2;
+    baseApp.upgrade({}, socket);
+    expect(socket.end).not.to.be.called;
   });
 });


### PR DESCRIPTION
There isn't really a "catch-all" like `res.finished` for the `upgrade` event. So if we're the only listener then we know we can close the connection. Otherwise we just pray whomever else has attached to the event knows what they're doing. Such is the case when using things like `socket.io`.