### PR TITLE
Rename `path` to `baseUrl` for path matching.

### DIFF
--- a/src/match/path.js
+++ b/src/match/path.js
@@ -23,7 +23,7 @@ export default (_path) => (_app = {}) => {
     matches: combine(app, (req) => {
       const params = regexp.exec(url(req).pathname);
       if (params) {
-        req.path = params[0];
+        req.baseUrl = params[0];
         req.params = req.params || {};
         keys.forEach(({name}, i) => {
           req.params[name] = params[i + 1];

--- a/src/serve.js
+++ b/src/serve.js
@@ -29,8 +29,8 @@ type Options = {
 
 const getBase = (req: IncomingMessage): string => {
   const url: URL = parse(req);
-  if (typeof req.path === 'string') {
-    return url.pathname.substr(req.path.length);
+  if (typeof req.baseUrl === 'string') {
+    return url.pathname.substr(req.baseUrl.length);
   }
   return url.pathname;
 };

--- a/test/spec/match/path.spec.js
+++ b/test/spec/match/path.spec.js
@@ -119,7 +119,9 @@ describe('path match', () => {
       url: '/foo/hello/baz/qux',
     }, {});
 
-    expect(yes).to.be.calledWithMatch((req) => req.path === '/foo/hello/baz');
+    expect(yes).to.be.calledWithMatch(
+      (req) => req.baseUrl === '/foo/hello/baz'
+    );
     expect(next).to.be.calledOnce;
   });
 

--- a/test/spec/serve.spec.js
+++ b/test/spec/serve.spec.js
@@ -42,7 +42,7 @@ describe('serve', () => {
     const app = serve({root: __dirname})(nextApp);
     app.request({
       url: '/foo/serve.spec.js',
-      path: '/foo',
+      baseUrl: '/foo',
       headers: {},
       method: 'GET',
     }, stream);


### PR DESCRIPTION
In `express` the value of `req.path` is read-only and setting it will blow things up.