### PR TITLE
Add new `pending` utility.

### DIFF
--- a/example/pending.js
+++ b/example/pending.js
@@ -1,0 +1,27 @@
+/* eslint no-console: 0 */
+import {send, use, compose, request, pending} from '../src';
+import {parse} from 'qs';
+import url from 'parseurl';
+
+const waits = [];
+
+// In one browser tab go to /wait
+// In another browser tab go to /unwait?name=Fred
+const createApp = compose(
+  use('/wait', pending((fn) => {
+    waits.push(fn);
+  })),
+  use('/unwait', request((req) => {
+    const query = parse(url(req).query);
+    const next = send(`Hello ${query.name}`);
+    waits.forEach((fn) => {
+      fn(next);
+    });
+    waits.length = 0;
+    return send('It is done.');
+  })),
+);
+
+const app = createApp();
+
+app.listen(8081);

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ export {default as logging} from './logging';
 export {default as match} from './match';
 export {default as middleware} from './middleware';
 export {default as use} from './use';
+export {default as pending} from './pending';
 export {default as pure} from './pure';
 export {default as proxy} from './proxy';
 export {default as redirect} from './redirect';

--- a/src/pending.js
+++ b/src/pending.js
@@ -1,0 +1,59 @@
+/* @flow */
+import compose from './compose';
+import request from './request';
+import status from './status';
+import send from './send';
+
+import type {AppCreator} from './types';
+
+type TriggerCallback = (a: AppCreator) => void;
+type Trigger = (c: TriggerCallback) => void;
+type Options = {
+  timeout: number,
+  onTimeout: AppCreator,
+};
+
+const defaultOnTimeout = compose(
+  status(500),
+  send('Timeout.'),
+);
+
+const defaultOptions = {
+  timeout: 10000,
+  onTimeout: defaultOnTimeout,
+};
+
+/**
+ * Pending allows you to wait for a given trigger before continuing the
+ * request chain. If this condition is not met within the given timeout then
+ * the `onTimeout` app is used instead. If the condition is met then the
+ * current app can be replaced.
+ * @param {Function} trigger Function invoked during the request which is
+ * passed a trigger callback. You call this trigger callback whenever you
+ * are ready to continue the request.
+ * @param {Object} options Options to control pending behaviour.
+ * @param {Number} options.timeout How long to wait before timing out.
+ * @param {Object} options.onTimeout App to use when timeout occurs.
+ * @returns {Function} App creator.
+ */
+const pending = (
+  trigger: Trigger,
+  options: Options = defaultOptions
+): AppCreator => {
+  const {
+    timeout = defaultOptions.timeout,
+    onTimeout = defaultOptions.onTimeout,
+  } = options;
+  return request(() => new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      resolve(onTimeout);
+    }, timeout);
+    const fn = (newApp) => {
+      clearTimeout(timer);
+      resolve(newApp);
+    };
+    trigger(fn);
+  }));
+};
+
+export default pending;

--- a/test/spec/pending.spec.js
+++ b/test/spec/pending.spec.js
@@ -1,0 +1,41 @@
+import {expect} from 'chai';
+import sinon from 'sinon';
+
+import pending from '../../src/pending';
+import next from '../../src/next';
+
+describe('pending', () => {
+  let clock;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+  });
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it('should invoke failure handler after timeout', () => {
+    const spy = sinon.spy();
+    const onTimeout = () => ({request: spy});
+    const app = pending((_fn) => {}, {timeout: 300, onTimeout})();
+    const promise = app.request({}, {});
+    clock.tick(300);
+    return promise.then(() => {
+      expect(spy).to.be.called;
+    });
+  });
+
+  it('should invoke correct app when trigger is applied', () => {
+    const spy = sinon.spy();
+    let f;
+    const app = pending((fn) => {
+      f = fn;
+    }, {timeout: 300})({request: spy});
+    const promise = app.request({}, {});
+    clock.tick(100);
+    f(next);
+    return promise.then(() => {
+      expect(spy).to.be.called;
+    });
+  });
+});


### PR DESCRIPTION
Pending allows you to wait for a given trigger before continuing the request chain. If this condition is not met within the given timeout then the `onTimeout` app is used instead. If the condition is met then the current app can be replaced.

Example:

```javascript
import {send, use, compose, request, pending} from '../src';
import {parse} from 'qs';
import url from 'parseurl';

const waits = [];

// In one browser tab go to /wait
// In another browser tab go to /unwait?name=Fred
const createApp = compose(
  use('/wait', pending((fn) => {
    waits.push(fn);
  })),
  use('/unwait', request((req) => {
    const query = parse(url(req).query);
    const next = send(`Hello ${query.name}`);
    waits.forEach((fn) => {
      fn(next);
    });
    waits.length = 0;
    return send('It is done.');
  })),
);

const app = createApp();

app.listen(8081);
```