### PR TITLE
Add `fetch` testing utility.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,14 +8,12 @@
       ]
     }
   },
-  "plugins": [
-    "@babel/plugin-proposal-object-rest-spread",
-  ],
   "presets": [
     ["@babel/preset-env", {
       "targets": {
         "node": 4
-      }
+      },
+      "shippedProposals": true
     }],
     "@babel/preset-flow"
   ]

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 /*.js
 match/**/*
 internal/**/*
+test/*.js
 lib/**/*
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ build
 /match
 /internal
 /lib
+/test/*.js
+/test/*.map
+/test/*.flow
 coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1358,7 +1358,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-      "dev": true,
       "requires": {
         "readable-stream": "2.3.3"
       }
@@ -1895,8 +1894,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "create-eslint-index": {
       "version": "1.0.0",
@@ -4388,8 +4386,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isemail": {
       "version": "2.2.1",
@@ -5361,8 +5358,7 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "2.0.0",
@@ -5509,7 +5505,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -6186,7 +6181,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -6809,8 +6803,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "prepublish": "npm run clean && npm run copy && npm run build && npm run import",
-    "clean": "./node_modules/.bin/rimraf lib ./*.js ./*.map ./*.flow match internal",
+    "clean": "./node_modules/.bin/rimraf lib ./*.js ./*.map ./*.flow match internal test/*.js test/*.map test/*.flow",
     "build": "./node_modules/.bin/babel --copy-files -s -d lib src",
     "copy": "./node_modules/.bin/ncp src lib && ./node_modules/.bin/renamer --regex --find '$' --replace '.flow' 'lib/**/*.js'",
     "import": "./node_modules/.bin/ncp lib .",
@@ -17,6 +17,7 @@
     "flow": "./node_modules/.bin/flow check"
   },
   "dependencies": {
+    "bl": "^1.2.1",
     "chalk": "^2.3.0",
     "compression": "^1.7.1",
     "cookies": "^0.7.1",

--- a/src/test/fetch.js
+++ b/src/test/fetch.js
@@ -1,0 +1,154 @@
+/* @flow */
+import bl from 'bl';
+
+import type {AppCreator, App} from '../types';
+import type {IncomingMessage, ServerResponse} from 'http';
+
+type Options = {
+  method: string,
+  headers: {[string]: string},
+  body: string | Buffer,
+  onError: (err: Error, req: IncomingMessage, res: ServerResponse) => void,
+  onNext: (req: IncomingMessage, res: ServerResponse) => void,
+};
+
+type MockedResponse = ServerResponse & {
+  body: string,
+  error: ?Error,
+};
+
+const fetch = (
+  appCreator: AppCreator,
+  path: string = '/',
+  _options: ?Options
+): Promise<MockedResponse> => {
+  let globalError = null;
+  const options = _options || {};
+  const stub: App = {
+    request: (req: IncomingMessage, res: ServerResponse) => {
+      options.onNext && options.onNext(req, res);
+    },
+    error: (err: Error, req: IncomingMessage, res: ServerResponse) => {
+      globalError = err;
+      options.onError && options.onError(err, req, res);
+    },
+    close: () => {},
+    upgrade: () => {},
+    listening: () => {},
+    stack: [],
+    matches: () => false,
+  };
+  const app = typeof appCreator === 'function' ? appCreator(stub) : appCreator;
+
+  let reqBodyStream;
+  const ensureReqBody = () => {
+    if (!reqBodyStream) {
+      reqBodyStream = bl(options.body || '');
+    }
+  };
+  const req = {
+    method: 'GET',
+    url: path,
+    headers: {},
+    getHeader: (name) => req.headers[name.toLowerCase()],
+    read: (...args) => {
+      ensureReqBody();
+      return reqBodyStream.read(...args);
+    },
+    pipe: (...args) => {
+      ensureReqBody();
+      return reqBodyStream.pipe(...args);
+    },
+    ...options,
+  };
+
+  let body;
+  let bodyStream;
+  let bodyActive = false;
+
+  const ensureBody = () => {
+    if (!body) {
+      body = new Promise((resolve, reject) => {
+        bodyStream = bl((err, result) => {
+          err ? reject(err) : resolve(result.toString('utf8'));
+        });
+      });
+    }
+  };
+
+  const res = {
+    headers: {},
+    statusCode: 200,
+    statusMessage: '',
+    headersSent: false,
+    finished: false,
+    getHeader: (name) => res.headers[name.toLowerCase()],
+    writeHead: (statusCode, msg, headers) => {
+      res.statusCode = statusCode;
+      if (typeof msg === 'string') {
+        res.statusMessage = msg;
+      }
+      if (typeof headers === 'undefined' && typeof msg === 'object') {
+        Object.assign(res.headers, msg);
+      } else if (typeof headers === 'object') {
+        Object.assign(res.headers, headers);
+      }
+      res.headersSent = true;
+    },
+    removeHeader: (n) => {
+      delete res.headers[n];
+    },
+    setHeader: (n, v) => {
+      res.headers[n.toLowerCase()] = v;
+    },
+    write: (...args) => {
+      res.headersSent = true;
+      bodyActive = true;
+      ensureBody();
+      return bodyStream.write(...args);
+    },
+    end: (...args) => {
+      res.headersSent = true;
+      bodyActive = true;
+      ensureBody();
+      return bodyStream.end(...args);
+    },
+    on: (...args) => {
+      ensureBody();
+      bodyStream.on(...args);
+      return res;
+    },
+    once: (...args) => {
+      ensureBody();
+      bodyStream.on(...args);
+      return res;
+    },
+    emit: (...args) => {
+      ensureBody();
+      bodyStream.emit(...args);
+      return res;
+    },
+    removeListener: (...args) => {
+      ensureBody();
+      bodyStream.removeListener(...args);
+      return res;
+    },
+  };
+  const realRes: MockedResponse = (res: any);
+  const result = app.request((req: any), realRes);
+  return Promise.resolve(result).then(() => {
+    if (globalError && !options.onError) {
+      return Promise.reject(globalError);
+    }
+    realRes.error = globalError;
+    if (bodyActive) {
+      return body.then((body) => {
+        realRes.body = body;
+        return realRes;
+      });
+    }
+    return realRes;
+  });
+};
+
+export default fetch;

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -1,0 +1,1 @@
+export {default as fetch} from './fetch';

--- a/test/spec/test/fetch.spec.js
+++ b/test/spec/test/fetch.spec.js
@@ -1,0 +1,128 @@
+import {expect} from 'chai';
+import sinon from 'sinon';
+import bl from 'bl';
+
+import fetch from '../../../src/test/fetch';
+import request from '../../../src/request';
+import next from '../../../src/next';
+import send from '../../../src/send';
+
+describe('test/fetch', () => {
+  it('should emulate `req.getHeader`', () => {
+    return fetch(request((req, res) => {
+      res.end(req.getHeader('foo'));
+      return next;
+    }), '/', {headers: {foo: 'bar'}}).then((res) => {
+      expect(res.body).to.equal('bar');
+    });
+  });
+  it('should emulate `res.writeHead` 1-arg', () => {
+    return fetch(request((req, res) => {
+      res.writeHead(202);
+      return next;
+    }), '/').then((res) => {
+      expect(res.statusCode).to.equal(202);
+    });
+  });
+  it('should emulate `res.removeHeader', () => {
+    return fetch(request((req, res) => {
+      res.headers.foo = 'bar';
+      res.removeHeader('foo');
+      return next;
+    }), '/').then((res) => {
+      expect(res.headers.foo).to.be.undefined;
+    });
+  });
+  it('should emulate `res.writeHead` 2-arg', () => {
+    return fetch(request((req, res) => {
+      res.writeHead(202, {foo: 'bar'});
+      return next;
+    }), '/').then((res) => {
+      expect(res.statusCode).to.equal(202);
+      expect(res.headers.foo).to.equal('bar');
+    });
+  });
+  it('should emulate `res.writeHead` 3-arg', () => {
+    return fetch(request((req, res) => {
+      res.writeHead(202, 'test', {foo: 'bar'});
+      return next;
+    }), '/').then((res) => {
+      expect(res.statusCode).to.equal(202);
+      expect(res.statusMessage).to.equal('test');
+      expect(res.headers.foo).to.equal('bar');
+    });
+  });
+  it('should support req string bodies', () => {
+    return fetch(request((req) => {
+      return new Promise((resolve, reject) => {
+        req.pipe(bl((err, data) => {
+          err ? reject(err) : resolve(send(data.toString('utf8')));
+        }));
+      });
+    }), '/', {body: 'hello'}).then((res) => {
+      expect(res.body).to.equal('hello');
+    });
+  });
+  it('should support req buffer bodies', () => {
+    return fetch(request((req) => {
+      return new Promise((resolve, reject) => {
+        req.pipe(bl((err, data) => {
+          err ? reject(err) : resolve(send(data.toString('utf8')));
+        }));
+      });
+    }), '/', {body: new Buffer('hello')}).then((res) => {
+      expect(res.body).to.equal('hello');
+    });
+  });
+  it('should have empty req body by default', () => {
+    return fetch(request((req) => {
+      expect(req.read()).to.equal(null);
+      return next;
+    }), '/');
+  });
+  it('should preserve the req body', () => {
+    return fetch(request((req) => {
+      expect(req.read(1).toString('utf8')).to.equal('a');
+      expect(req.read(1).toString('utf8')).to.equal('b');
+      return next;
+    }), '/', {body: bl('ab')});
+  });
+  it('should support req stream bodies', () => {
+    return fetch(request((req) => {
+      return new Promise((resolve, reject) => {
+        req.pipe(bl((err, data) => {
+          err ? reject(err) : resolve(send(data.toString('utf8')));
+        }));
+      });
+    }), '/', {body: bl('hello')}).then((res) => {
+      expect(res.body).to.equal('hello');
+    });
+  });
+
+  // TODO: Make this better.
+  it('should provide default app handlers', () => {
+    fetch((app) => {
+      app.close();
+      app.upgrade();
+      app.listening();
+      app.matches();
+      return app;
+    }, '/');
+  });
+  it('should support `onNext`', () => {
+    const spy = sinon.spy();
+    return fetch(next, '/', {onNext: spy}).then(() => {
+      expect(spy).to.be.called;
+    });
+  });
+  it('should bubble res stream errors', () => {
+    const piper = bl('pipe');
+    return fetch(request((req, res) => {
+      piper.pipe(res);
+      piper.emit('error', new Error('fail'));
+      return next;
+    }), '/', {onError: next}).catch((error) => {
+      expect(error).to.be.an.instanceof(Error);
+    });
+  });
+});


### PR DESCRIPTION
The `fetch` utility can be used to test your `midori` apps easily without having to spin up a dedicated server for every test. It works mostly like the usual what-wg `fetch` except it takes a midori app or app creator as its first argument and the promise result is closer to a node `ServerResponse` than anything else. Usage highlights can be found in `send.spec.js` and `server.spec.js` for now, as those two relied most heavily on the actual body content of the response.

Example:

```js
import {request, next} from 'midori';
import {fetch} from 'midori/test';
 
const baseApp = request((req, res) => {
  res.setHeader('Content-Type', 'test');
  return next;
});
 
return fetch(baseApp, '/').then((res) => {
  assert(res.headers['content-type'] === 'test');
});
```