### PR TITLE
Allow access to `proxyReq` and `proxyRes` events.

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -3,12 +3,7 @@ import Proxy from 'http-proxy';
 import baseApp from './internal/baseApp';
 
 import type {App, AppCreator} from './types';
-
-/**
-TODO: Handle these events:
-proxy.on('proxyReq', (proxyReq, req, res, options) => { });
-proxy.on('proxyRes', (proxyRes, req, res) => { });
-*/
+import type {ClientRequest, IncomingMessage} from 'http';
 
 type Options = {
   target?: string | {host: string, port: number},
@@ -31,10 +26,18 @@ type Options = {
   cookieDomainRewrite?: false | string | {[string]: string},
   headers?: {[string]: string},
   proxyTimeout?: number,
-}
+  onRequest?: (ClientRequest) => void,
+  onResponse?: (IncomingMessage) => void,
+};
 
 export default function(options: Options): AppCreator {
   const proxy = Proxy.createProxy();
+  if (options.onRequest) {
+    proxy.on('proxyReq', options.onRequest);
+  }
+  if (options.onResponse) {
+    proxy.on('proxyRes', options.onResponse);
+  }
   return (_app: App) => {
     const app = {
       ...baseApp,

--- a/test/spec/proxy.spec.js
+++ b/test/spec/proxy.spec.js
@@ -13,6 +13,7 @@ describe('proxy', () => {
     sandbox.stub(Proxy, 'createProxy').returns(server = {
       ws: sandbox.stub(),
       web: sandbox.stub(),
+      on: sandbox.stub(),
     });
   });
 
@@ -34,5 +35,17 @@ describe('proxy', () => {
     const app = proxy(options)({upgrade: spy});
     app.upgrade(1, 2, 3);
     expect(server.ws).to.be.calledWith(1, 2, 3, options);
+  });
+
+  it('shoud hook `proxyReq`', () => {
+    const options = {onRequest: 5};
+    proxy(options);
+    expect(server.on).to.be.calledWith('proxyReq', 5);
+  });
+
+  it('shoud hook `proxyRes`', () => {
+    const options = {onResponse: 5};
+    proxy(options);
+    expect(server.on).to.be.calledWith('proxyRes', 5);
   });
 });


### PR DESCRIPTION
You can use these to do body rewriting or similar such things.

```javascript
proxy({
  target: 'http://foo.com',
  onResponse: (res) => {
    if (res.statusCode === 302) {
      const string = 'hello';
      const body = bl(string);
      res.statusCode = 200;
      res.statusMessage = 'OK';
      res.headers['content-length'] = string.length;
      res.pipe = body.pipe.bind(body);
      res.destroy();
    }
  },
})
```