### PR TITLE
Support `dispose` behaviour in `pending`.

### DIFF
--- a/test/spec/pending.spec.js
+++ b/test/spec/pending.spec.js
@@ -18,7 +18,7 @@ describe('pending', () => {
     const spy = sinon.spy();
     const onTimeout = () => ({request: spy});
     const app = pending((_fn) => {}, {timeout: 300, onTimeout})();
-    const promise = app.request({}, {});
+    const promise = app.request({on: () => {}}, {});
     clock.tick(300);
     return promise.then(() => {
       expect(spy).to.be.called;
@@ -31,11 +31,27 @@ describe('pending', () => {
     const app = pending((fn) => {
       f = fn;
     }, {timeout: 300})({request: spy});
-    const promise = app.request({}, {});
+    const promise = app.request({on: () => {}}, {});
     clock.tick(100);
     f(next);
     return promise.then(() => {
       expect(spy).to.be.called;
+    });
+  });
+
+  it('should handle disposer normally', () => {
+    const spy = sinon.spy();
+    const spy2 = sinon.spy();
+    let f;
+    const app = pending((fn) => {
+      f = fn;
+      return spy2;
+    }, {timeout: 300})({request: spy});
+    const promise = app.request({on: () => {}}, {});
+    clock.tick(100);
+    f(next);
+    return promise.then(() => {
+      expect(spy2).to.be.called;
     });
   });
 });


### PR DESCRIPTION
Allow users to define an action that occurs when the `pending` result has completed whether from error, user request abort or resolution. This is often useful for removing listeners that were previously attached.