### PR TITLE
Invoke `listening` if server is already listening.

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -29,7 +29,7 @@ export default function connect(app: App | AppCreator, server: Server) {
     }
   });
   if (server.listening === true) {
-    app.listening.call(server);
+    app.listening.call(server, server);
   }
   return server;
 }

--- a/src/connect.js
+++ b/src/connect.js
@@ -28,5 +28,8 @@ export default function connect(app: App | AppCreator, server: Server) {
       server.on(evt, app[evt]);
     }
   });
+  if (server.listening === true) {
+    app.listening.call(server);
+  }
   return server;
 }

--- a/src/listening.js
+++ b/src/listening.js
@@ -1,0 +1,14 @@
+// @flow
+import type {Server} from 'http';
+import type {App} from './types';
+type Listening = (server: Server) => void | (() => void);
+
+export default (listener: Listening) => (app: App) => {
+  return {
+    ...app,
+    listening() {
+      listener(this);
+      app.listening(this);
+    },
+  };
+};

--- a/src/types.js
+++ b/src/types.js
@@ -1,12 +1,12 @@
 // @flow
-import type {IncomingMessage, ServerResponse} from 'http';
+import type {IncomingMessage, ServerResponse, Server} from 'http';
 import type {Socket} from 'net';
 
 export type App = {
   request: (req: IncomingMessage, res: ServerResponse) => mixed,
   error: (err: Error, req: IncomingMessage, res: ServerResponse) => mixed,
   close: () => void,
-  listening: () => void,
+  listening: (server: Server) => void,
   upgrade: (req: IncomingMessage, socket: Socket, head: Buffer) => void,
 };
 

--- a/test/spec/connect.spec.js
+++ b/test/spec/connect.spec.js
@@ -44,4 +44,13 @@ describe('http', () => {
     expect(spy1).to.be.calledOnce;
     expect(spy2).not.be.called;
   });
+
+  it('should invoke `listening` if already listening', () => {
+    const spy1 = sinon.spy();
+    const app = {listening: spy1};
+    const server = new EventEmitter();
+    server.listening = true;
+    connect(app, server);
+    expect(spy1).to.be.calledOnce;
+  });
 });

--- a/test/spec/listening.spec.js
+++ b/test/spec/listening.spec.js
@@ -1,0 +1,15 @@
+import {expect} from 'chai';
+import sinon from 'sinon';
+
+import listening from '../../src/listening';
+
+describe('request', () => {
+  it('should call the next handler in sequence', () => {
+    const spy = sinon.spy();
+    const app = listening(() => {
+      return;
+    })({listening: spy});
+    app.listening();
+    expect(spy).to.be.called;
+  });
+});


### PR DESCRIPTION
If you connect an app that has a `listening` handler you would expect this to be called if the server is listening. I guess this deviates from the normal spec a little but this feels largely like intended behaviour. Especially if you wish to do things like setup or teardown.

Will have to think on this a bit.