### PR TITLE
Bubble test `on` and `once` for request objects.

### DIFF
--- a/src/test/fetch.js
+++ b/src/test/fetch.js
@@ -57,7 +57,22 @@ const fetch = (
       ensureReqBody();
       return reqBodyStream.pipe(...args);
     },
+    on: (...args) => {
+      ensureReqBody();
+      reqBodyStream.on(...args);
+      return req;
+    },
+    once: (...args) => {
+      ensureReqBody();
+      reqBodyStream.on(...args);
+      return req;
+    },
     ...options,
+    // flowlint-next-line unsafe-getters-setters:off
+    get body() {
+      ensureReqBody();
+      return reqBodyStream;
+    },
   };
 
   let body;

--- a/test/spec/test/fetch.spec.js
+++ b/test/spec/test/fetch.spec.js
@@ -99,6 +99,26 @@ describe('test/fetch', () => {
     });
   });
 
+  it('should support req `once`', () => {
+    return fetch(request((req) => {
+      const result = new Promise((resolve) => {
+        req.once('foo', () => resolve(next));
+      });
+      req.body.emit('foo');
+      return result;
+    }), '/');
+  });
+
+  it('should support req `on`', () => {
+    return fetch(request((req) => {
+      const result = new Promise((resolve) => {
+        req.on('foo', () => resolve(next));
+      });
+      req.body.emit('foo');
+      return result;
+    }), '/');
+  });
+
   // TODO: Make this better.
   it('should provide default app handlers', () => {
     fetch((app) => {


### PR DESCRIPTION
Does what it says on the box. Some people access `req.on('close', ...)` and this allows for that to be tested without anything blowing up.