### PR TITLE
Allow mocking of selectors during tests.

### DIFF
--- a/src/createSelector.js
+++ b/src/createSelector.js
@@ -46,6 +46,8 @@ const createSelector: CS<App> = <R>(
     const result = apply(...selectors, next);
     return result;
   };
+  out._selectors = selectors;
+  out._selector = selector;
   return out;
 };
 

--- a/src/internal/isSelector.js
+++ b/src/internal/isSelector.js
@@ -1,0 +1,6 @@
+// @flow
+const isSelector = (app: mixed): boolean => {
+  return typeof app === 'function' && typeof app._selector === 'function';
+};
+
+export default isSelector;

--- a/src/request.js
+++ b/src/request.js
@@ -31,4 +31,6 @@ const request = (handler: RequestHandler): App => (app) => {
   };
 };
 
+request._selector = () => null;
+
 export default request;

--- a/src/response.js
+++ b/src/response.js
@@ -188,7 +188,7 @@ export const installUpgradeResponse = (
  * @param {Function} handler Request handler. Must return another app.
  * @returns {App} App instance.
  */
-export default (handler: RequestHandler): App => (app) => {
+const response = (handler: RequestHandler): App => (app) => {
   return {
     ...app,
     request: async (req, res) => {
@@ -211,3 +211,7 @@ export default (handler: RequestHandler): App => (app) => {
     },
   };
 };
+
+response._selector = () => null;
+
+export default response;

--- a/src/test/createMockRequest.js
+++ b/src/test/createMockRequest.js
@@ -1,0 +1,82 @@
+// @flow
+import bl from 'bl';
+import type {Readable} from 'stream';
+
+type Options = {
+  url?: string,
+  method?: string,
+  body?: string | Buffer | Readable,
+  headers?: {[string]: string},
+  offline?: boolean,
+  encrypted?: boolean,
+};
+
+const createMockRequest = (options: Options) => {
+  let reqBodyStream: Readable;
+  const ensureReqBody = () => {
+    if (!reqBodyStream) {
+      if (typeof options.body === 'string' || Buffer.isBuffer(options.body)) {
+        reqBodyStream = bl(options.body);
+      } else if (options.body && typeof options.body.read === 'function') {
+        // flowlint-next-line unclear-type: off
+        reqBodyStream = (options.body: any);
+      } else if (typeof options.body === 'undefined') {
+        reqBodyStream = bl('');
+      } else {
+        throw new TypeError('Invalid request body given.');
+      }
+    }
+  };
+  const rawHeaders = options.headers || {};
+  Object.keys(rawHeaders).forEach((k) => {
+    rawHeaders[k.toLowerCase()] = rawHeaders[k];
+  });
+  const req = {
+    method: typeof options.method === 'string' ? options.method : 'GET',
+    url: typeof options.url === 'string' ? options.url : '/',
+    headers: rawHeaders,
+    // flowlint-next-line unclear-type: off
+    read: (...args: any) => {
+      ensureReqBody();
+      return reqBodyStream.read(...args);
+    },
+    // flowlint-next-line unclear-type: off
+    pipe: (...args: any) => {
+      ensureReqBody();
+      return reqBodyStream.pipe(...args);
+    },
+    // flowlint-next-line unclear-type: off
+    on: (...args: any) => {
+      ensureReqBody();
+      reqBodyStream.on(...args);
+      return req;
+    },
+    // flowlint-next-line unclear-type: off
+    once: (...args: any) => {
+      ensureReqBody();
+      reqBodyStream.on(...args);
+      return req;
+    },
+    // flowlint-next-line unclear-type: off
+    removeListener: (...args: any) => {
+      ensureReqBody();
+      reqBodyStream.removeListener(...args);
+      return req;
+    },
+    connection: {
+      encrypted: options.encrypted,
+    },
+    // TODO: Consider stubbing more of this?
+    socket: {
+      _handle: options.offline === true ? null : 1,
+    },
+    // flowlint-next-line unsafe-getters-setters:off
+    get body() {
+      ensureReqBody();
+      return reqBodyStream;
+    },
+  };
+  return req;
+};
+
+export default createMockRequest;

--- a/src/test/createMockResponse.js
+++ b/src/test/createMockResponse.js
@@ -1,0 +1,116 @@
+// @flow
+/* eslint-disable no-use-before-define */
+import bl from 'bl';
+import type {ServerResponse} from 'http';
+import type {Socket} from 'net';
+
+type MockedResponse = ServerResponse & {
+  socket: Socket,
+  statusMessage: ?string,
+  body: ?Promise<string>,
+  bodyActive: boolean,
+  headers: {[string]: string | Array<string>},
+};
+
+const createMockResponse = (): MockedResponse => {
+  const res = {};
+
+  const ensureBody = () => {
+    if (!res.body) {
+      res.body = new Promise((resolve, reject) => {
+        res.bodyStream = bl((err, result) => {
+          err ? reject(err) : resolve(result.toString('utf8'));
+        });
+      });
+    }
+  };
+
+  const socket = {
+    write(...args) {
+      res.bodyActive = true;
+      ensureBody();
+      return res.bodyStream.write(...args);
+    },
+    end(...args) {
+      res.bodyActive = true;
+      ensureBody();
+      return res.bodyStream.end(...args);
+    },
+    on(...args) {
+      if (args[0] === 'unpipe') {
+        res.bodyActive = true;
+      }
+      ensureBody();
+      res.bodyStream.on(...args);
+      return this;
+    },
+    once(...args) {
+      ensureBody();
+      res.bodyStream.once(...args);
+      return this;
+    },
+    emit(...args) {
+      ensureBody();
+      res.bodyStream.emit(...args);
+      return this;
+    },
+    removeListener(...args) {
+      ensureBody();
+      res.bodyStream.removeListener(...args);
+      return this;
+    },
+    // flowlint-next-line unsafe-getters-setters:off
+    get writable() {
+      ensureBody();
+      return res.bodyStream.writable;
+    },
+  };
+
+  Object.assign(res, socket, {
+    headers: {},
+    statusCode: undefined,
+    statusMessage: undefined,
+    headersSent: false,
+    finished: false,
+    socket,
+    getHeader(name) {
+      return this.headers[name.toLowerCase()];
+    },
+    writeHead: (statusCode, msg, headers) => {
+      res.statusCode = statusCode;
+      if (typeof msg === 'string') {
+        res.statusMessage = msg;
+      }
+      if (typeof headers === 'undefined' && typeof msg === 'object') {
+        Object.assign(res.headers, msg);
+      } else if (typeof headers === 'object') {
+        Object.assign(res.headers, headers);
+      }
+      Object.keys(res.headers).forEach((k) => {
+        res.headers[k.toLowerCase()] = res.headers[k];
+      });
+      res.headersSent = true;
+    },
+    removeHeader: (n) => {
+      delete res.headers[n];
+      delete res.headers[n.toLowerCase()];
+    },
+    setHeader: (n, v) => {
+      res.headers[n] = v;
+      res.headers[n.toLowerCase()] = v;
+    },
+    write(...args) {
+      this.headersSent = true;
+      return socket.write.apply(this, args);
+    },
+    end(...args) {
+      this.headersSent = true;
+      return socket.end.apply(this, args);
+    },
+  });
+
+  // flowlint-next-line unclear-type: off
+  return (res: any);
+};
+
+export default createMockResponse;

--- a/src/test/fetch.js
+++ b/src/test/fetch.js
@@ -1,9 +1,11 @@
 /* @flow */
-import bl from 'bl';
+import createMockRequest from './createMockRequest';
+import createMockResponse from './createMockResponse';
 
 import type {App} from '../types';
 import type {IncomingMessage, ServerResponse} from 'http';
 import type {Readable} from 'stream';
+import type {Socket} from 'net';
 import {getUpgradeResponse} from '../response';
 
 type Options = {
@@ -18,16 +20,19 @@ type Options = {
 };
 
 type MockedResponse = ServerResponse & {
-  body: string,
+  statusMessage: ?string,
+  body: ?Promise<string>,
+  bodyActive: boolean,
+  headers: {[string]: string | Array<string>},
+  result: mixed,
   error: ?Error,
-  result: ?mixed,
+  socket: Socket,
 };
 
-// eslint-disable-next-line
 const fetch = async (
   App: App,
-  path: string = '/',
-  _options: ?Options,
+  url?: string,
+  _options?: Options,
 ): Promise<MockedResponse> => {
   let globalError = null;
   const options = _options || {};
@@ -56,180 +61,31 @@ const fetch = async (
   }
   const app = App(stub);
 
-  let reqBodyStream: Readable;
-  const ensureReqBody = () => {
-    if (!reqBodyStream) {
-      if (typeof options.body === 'string' || Buffer.isBuffer(options.body)) {
-        reqBodyStream = bl(options.body);
-      } else if (options.body && typeof options.body.read === 'function') {
-        // FIXME: Flow dislikes duck typing.
-        // $ExpectError
-        reqBodyStream = options.body;
-      } else if (typeof options.body === 'undefined') {
-        reqBodyStream = bl('');
-      } else {
-        throw new TypeError('Invalid request body given.');
-      }
-    }
-  };
-  const rawHeaders = options.headers || {};
-  Object.keys(rawHeaders).forEach((k) => {
-    rawHeaders[k.toLowerCase()] = rawHeaders[k];
+  let req = createMockRequest({
+    url,
+    method: options.method,
+    headers: options.headers,
+    body: options.body,
+    encrypted: options.encrypted,
+    offline: options.offline,
   });
-  let req = {
-    method: options.method || 'GET',
-    url: path,
-    headers: rawHeaders,
-    read: (...args) => {
-      ensureReqBody();
-      return reqBodyStream.read(...args);
-    },
-    pipe: (...args) => {
-      ensureReqBody();
-      return reqBodyStream.pipe(...args);
-    },
-    on: (...args) => {
-      ensureReqBody();
-      reqBodyStream.on(...args);
-      return req;
-    },
-    once: (...args) => {
-      ensureReqBody();
-      reqBodyStream.on(...args);
-      return req;
-    },
-    removeListener: (...args) => {
-      ensureReqBody();
-      reqBodyStream.removeListener(...args);
-      return req;
-    },
-    connection: {
-      encrypted: options.encrypted,
-    },
-    // TODO: Consider stubbing more of this?
-    socket: {
-      _handle: options.offline === true ? null : 1,
-    },
-    // flowlint-next-line unsafe-getters-setters:off
-    get body() {
-      ensureReqBody();
-      return reqBodyStream;
-    },
-  };
-  if (options && options.mapRequest) {
+  const res = createMockResponse();
+
+  if (options.mapRequest) {
     // $ExpectError
     req = options.mapRequest((req: any));
   }
-
-  let body;
-  let bodyStream;
-  let bodyActive = false;
-
-  const ensureBody = () => {
-    if (!body) {
-      body = new Promise((resolve, reject) => {
-        bodyStream = bl((err, result) => {
-          err ? reject(err) : resolve(result.toString('utf8'));
-        });
-      });
-    }
-  };
-
-  const socket = {
-    write(...args) {
-      bodyActive = true;
-      ensureBody();
-      return bodyStream.write(...args);
-    },
-    end(...args) {
-      bodyActive = true;
-      ensureBody();
-      return bodyStream.end(...args);
-    },
-    on(...args) {
-      if (args[0] === 'unpipe') {
-        bodyActive = true;
-      }
-      ensureBody();
-      bodyStream.on(...args);
-      return this;
-    },
-    once(...args) {
-      ensureBody();
-      bodyStream.once(...args);
-      return this;
-    },
-    emit(...args) {
-      ensureBody();
-      bodyStream.emit(...args);
-      return this;
-    },
-    removeListener(...args) {
-      ensureBody();
-      bodyStream.removeListener(...args);
-      return this;
-    },
-    // flowlint-next-line unsafe-getters-setters:off
-    get writable() {
-      ensureBody();
-      return bodyStream.writable;
-    },
-  };
-
-  const res = {
-    headers: {},
-    statusCode: undefined,
-    statusMessage: undefined,
-    headersSent: false,
-    finished: false,
-    socket,
-    getHeader(name) {
-      return this.headers[name.toLowerCase()];
-    },
-    writeHead: (statusCode, msg, headers) => {
-      res.statusCode = statusCode;
-      if (typeof msg === 'string') {
-        res.statusMessage = msg;
-      }
-      if (typeof headers === 'undefined' && typeof msg === 'object') {
-        Object.assign(res.headers, msg);
-      } else if (typeof headers === 'object') {
-        Object.assign(res.headers, headers);
-      }
-      Object.keys(res.headers).forEach((k) => {
-        res.headers[k.toLowerCase()] = res.headers[k];
-      });
-      res.headersSent = true;
-    },
-    removeHeader: (n) => {
-      delete res.headers[n];
-      delete res.headers[n.toLowerCase()];
-    },
-    setHeader: (n, v) => {
-      res.headers[n] = v;
-      res.headers[n.toLowerCase()] = v;
-    },
-    ...socket,
-    write(...args) {
-      this.headersSent = true;
-      return socket.write.apply(this, args);
-    },
-    end(...args) {
-      this.headersSent = true;
-      return socket.end.apply(this, args);
-    },
-  };
 
   // TODO: FIXME: Any better way of casting through `any`?
   // flowlint-next-line unclear-type: off
   const realRes: MockedResponse = (res: any);
   let result;
   if (
-    req.headers.connection &&
+    typeof req.headers.connection === 'string' &&
     req.headers.connection.toLowerCase() === 'upgrade'
   ) {
     // flowlint-next-line unclear-type: off
-    result = await app.upgrade((req: any), (socket: any), new Buffer(''));
+    result = await app.upgrade((req: any), (res.socket: any), new Buffer(''));
   } else {
     // flowlint-next-line unclear-type: off
     result = await app.request((req: any), realRes);
@@ -249,10 +105,10 @@ const fetch = async (
   }
   realRes.error = globalError;
   realRes.result = result;
-  if (bodyActive) {
+  if (res.bodyActive) {
     // FIXME: flow being stupid again
     // $ExpectError
-    realRes.body = await body;
+    realRes.body = await res.body;
     return realRes;
   }
   return realRes;

--- a/src/test/getSelectorImplementation.js
+++ b/src/test/getSelectorImplementation.js
@@ -1,0 +1,12 @@
+// @flow
+import isSelector from '../internal/isSelector';
+import type {App} from '../types';
+
+const getSelectorImplementation = (app: App) => {
+  if (isSelector(app)) {
+    return app._selector;
+  }
+  throw new TypeError('Must pass valid selector.');
+};
+
+export default getSelectorImplementation;

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -1,2 +1,8 @@
 // @flow
 export {default as fetch} from './fetch';
+export {default as runSelector} from './runSelector';
+export {
+  default as getSelectorImplementation,
+} from './getSelectorImplementation';
+export {default as createMockRequest} from './createMockRequest';
+export {default as createMockResponse} from './createMockResponse';

--- a/src/test/runSelector.js
+++ b/src/test/runSelector.js
@@ -1,0 +1,51 @@
+// @flow
+import isSelector from '../internal/isSelector';
+import type {App} from '../types';
+
+class MockEnvironment {
+  values: Map<mixed, mixed>;
+  constructor() {
+    this.values = new Map();
+  }
+  mockValue(selector, value) {
+    this.values.set(selector, value);
+  }
+  hasValueFor(selector) {
+    return this.values.has(selector);
+  }
+  valueFor(selector) {
+    return this.values.get(selector);
+  }
+}
+
+const runSelectorInternal = async <T>(
+  app: ((T) => App) => App,
+  env: MockEnvironment,
+): Promise<T> => {
+  if (isSelector(app)) {
+    if (env.hasValueFor(app)) {
+      // flowlint-next-line unclear-type: off
+      return (env.valueFor(app): any);
+    }
+    const args = [];
+    for (const selectorApp of app._selectors) {
+      args.push(await runSelectorInternal(selectorApp, env));
+    }
+
+    const result = await app._selector(...args);
+    env.mockValue(app, result);
+    return result;
+  }
+  throw new TypeError('Must pass valid selector.');
+};
+
+const runSelector = async <T>(
+  app: ((T) => App) => App,
+  fn: (env: MockEnvironment) => void = () => {},
+): Promise<T> => {
+  const env = new MockEnvironment();
+  fn(env);
+  return await runSelectorInternal(app, env);
+};
+
+export default runSelector;

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -14,7 +14,7 @@ type UpgradeHandler = ({
  * @param {Function} handler Request handler. Must return another app creator.
  * @returns {App} App instance.
  */
-export default (handler: UpgradeHandler): App => (app) => {
+const upgrade = (handler: UpgradeHandler): App => (app) => {
   return {
     ...app,
     upgrade: async (req, socket, head) => {
@@ -32,3 +32,7 @@ export default (handler: UpgradeHandler): App => (app) => {
     },
   };
 };
+
+upgrade._selector = () => null;
+
+export default upgrade;

--- a/test/spec/test/runSelector.spec.js
+++ b/test/spec/test/runSelector.spec.js
@@ -1,0 +1,21 @@
+import createSelector from '../../../src/createSelector';
+import request from '../../../src/request';
+import runSelector from '../../../src/test/runSelector';
+
+describe('/test/runSelector', () => {
+  it('should mock dependencies', async () => {
+    const sel = createSelector(request, (req) => req.status);
+    const result = await runSelector(sel, (env) => {
+      env.mockValue(request, {status: 101});
+    });
+    expect(result).toEqual(101);
+  });
+  it('should fail on non-selectors', async () => {
+    await expect(runSelector(5)).rejects.toThrow(TypeError);
+  });
+  it('should basic', async () => {
+    const sel = createSelector(() => 101);
+    const result = await runSelector(sel);
+    expect(result).toEqual(101);
+  });
+});


### PR DESCRIPTION
 * Add `createMockRequest`, `createMockResponse` test functions.
 * Add `runSelector` and `getSelectorImplementation` test functions.

Instead of running through the entire request lifecycle, `runSelector` allows you to just test the value and execution of a single selector, while mocking out all the selectors it depends on. Examples and usage can be found in the README. `createMockRequest` and `createMockResponse` have been extracted to allow the mocking of the `request` "selector".